### PR TITLE
update denops/test

### DIFF
--- a/denops/denippet/deps/denops.ts
+++ b/denops/denippet/deps/denops.ts
@@ -8,4 +8,4 @@ export * as au from "https://deno.land/x/denops_std@v6.5.0/autocmd/mod.ts";
 export * as lambda from "https://deno.land/x/denops_std@v6.5.0/lambda/mod.ts";
 export { batch } from "https://deno.land/x/denops_std@v6.5.0/batch/mod.ts";
 
-export { test } from "jsr:@denops/test@2.0.1";
+export { test } from "jsr:@denops/test@3.0.4";

--- a/denops/denippet/main_test.ts
+++ b/denops/denippet/main_test.ts
@@ -6,7 +6,7 @@ import { is } from "./deps/unknownutil.ts";
 async function loadPlugin(denops: Denops): Promise<void> {
   const runtimepath = path.resolve(path.fromFileUrl(new URL("../..", import.meta.url)));
   await denops.cmd(`set runtimepath^=${runtimepath}`);
-  await denops.call("denops#plugin#register", "denippet");
+  await denops.call("denops#plugin#discover");
   await denops.call("denops#plugin#wait", "denippet");
 }
 

--- a/denops/denippet/snippet.ts
+++ b/denops/denippet/snippet.ts
@@ -26,7 +26,9 @@ export class Snippet {
     const snippetNode = await parse(denops, body);
 
     // Resolve reference relationships using breadth first search.
-    const isJumpable = (token: Node.Node): token is Node.Jumpable => token.isJumpable();
+    const isJumpable = (
+      token: Node.Node,
+    ): token is Node.Tabstop | Node.Placeholder | Node.Choice => token.isJumpable();
     const nodeQueue = snippetNode.children.filter((node) => node.type !== "text");
     // Key is tabstop
     const jumpableNodeMap = new Map<number, Node.Jumpable>();


### PR DESCRIPTION
## Background
- `deno task test` failed with a `[denops-test] Connection failed error`.
- Updating the Denops test library fixed the issue.

## Changes
- Updated denops/test to the latest version.
- Replaced `denops#plugin#register()` with `denops#plugin#discover`,as the former has been removed.
   -  https://github.com/vim-denops/denops.vim/pull/344/commits/5f436285db9d8a6628eea54150b1a23187788591 

## Checklist
- [x] Tests pass successfully